### PR TITLE
Add profile test page with hero gradient and accordions

### DIFF
--- a/src/app/test/profile/page.tsx
+++ b/src/app/test/profile/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import Image from 'next/image';
+import {useState} from 'react';
+import styles from './profile.module.css';
+
+const accolades = [
+  {
+    title: 'Education',
+    items: [
+      'J.D., Osgoode Hall Law School',
+      'B.A., Political Science, McGill University',
+      'Certified Specialist in Family Law',
+    ],
+  },
+  {
+    title: 'Bar Admissions',
+    items: ['Law Society of Ontario', 'Ontario Superior Court of Justice', 'Ontario Court of Appeal'],
+  },
+  {
+    title: 'Memberships & Affiliations',
+    items: [
+      "Advocates' Society",
+      'Ontario Bar Association – Family Law Section',
+      'International Academy of Family Lawyers',
+      'Association of Family and Conciliation Courts',
+    ],
+  },
+  {
+    title: 'Representative Work',
+    items: [
+      'Successfully represented high net-worth clients in complex equalization disputes.',
+      'Negotiated multi-jurisdictional parenting arrangements with creative dispute resolution models.',
+      'Counsel to business owners navigating corporate valuations within family law matters.',
+    ],
+  },
+];
+
+function Accordion({title, items, defaultOpen = false}: {title: string; items: string[]; defaultOpen?: boolean}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+  return (
+    <div className={styles.accordion}>
+      <button
+        className={styles.accordionToggle}
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
+        <span>{title}</span>
+        <svg className={open ? styles.iconOpen : styles.icon} viewBox="0 0 24 24" aria-hidden>
+          <path d="M12 5v14m-7-7h14" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      <div id={panelId} className={open ? styles.accordionBodyOpen : styles.accordionBody} role="region" aria-hidden={!open}>
+        <ul>
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default function ProfileTestPage() {
+  return (
+    <div className={styles.wrapper}>
+      <section className={styles.hero}>
+        <div className={styles.gradient}></div>
+        <div className={styles.heroInner}>
+          <div className={styles.meta}>
+            <p className={styles.breadcrumb}>Our Team / Partner</p>
+            <h1 className={styles.title}>Rachel Healey</h1>
+            <p className={styles.subtitle}>Partner &amp; Family Law Advocate</p>
+            <div className={styles.contactRow}>
+              <a className={styles.primaryButton} href="mailto:rachel.healey@example.com">
+                Email Rachel
+              </a>
+              <a className={styles.secondaryButton} href="tel:+14160000000">
+                416.000.0000
+              </a>
+            </div>
+            <div className={styles.quickFacts}>
+              <div>
+                <span className={styles.factLabel}>Location</span>
+                <span className={styles.factValue}>Toronto, Ontario</span>
+              </div>
+              <div>
+                <span className={styles.factLabel}>Practice Focus</span>
+                <span className={styles.factValue}>Family Law, Mediation, Parenting Coordination</span>
+              </div>
+            </div>
+          </div>
+          <div className={styles.heroImageWrap}>
+            <div className={styles.imageHalo}></div>
+            <div className={styles.imageMask}>
+              <Image src="https://placehold.co/600x900/png" alt="Rachel Healey" width={600} height={900} priority />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.body}>
+        <div className={styles.intro}>
+          <h2>Advocacy with empathy, strategy with resolve.</h2>
+          <p>
+            Rachel partners with clients through every phase of complex family law matters with a focus on
+            strategic planning, collaborative problem solving, and dignified advocacy. She is known for managing
+            high-conflict matters that require discretion, financial literacy, and a calm, compassionate voice.
+          </p>
+          <p>
+            Whether navigating parenting disputes, business valuations, or cross-border relocation cases, Rachel
+            approaches each file with meticulous preparation and a tireless commitment to achieving practical
+            solutions. She leverages a broad network of multidisciplinary professionals to ensure that clients feel
+            supported beyond the legal process.
+          </p>
+        </div>
+
+        <aside className={styles.sidebar}>
+          <div className={styles.card}>
+            <h3>Key Highlights</h3>
+            <ul>
+              <li>Trusted advisor to entrepreneurs and executives in high-stakes separation matters.</li>
+              <li>Regular speaker on alternative dispute resolution and trauma-informed advocacy.</li>
+              <li>Certified mediator with a focus on child-centric parenting plans.</li>
+            </ul>
+          </div>
+          <div className={styles.card}>
+            <h3>Notable Recognition</h3>
+            <ul>
+              <li>Best Lawyers in Canada – Family Law (2021-2024)</li>
+              <li>Lexpert Rising Star – Leading Lawyer Under 40</li>
+              <li>Ontario Bar Association Volunteer Service Award</li>
+            </ul>
+          </div>
+        </aside>
+      </section>
+
+      <section className={styles.details}>
+        <div className={styles.accordionGrid}>
+          {accolades.map((section, index) => (
+            <Accordion key={section.title} title={section.title} items={section.items} defaultOpen={index === 0} />
+          ))}
+        </div>
+        <div className={styles.quoteBlock}>
+          <blockquote>
+            “My role is to restore clarity when emotions run high. Clients deserve an advocate who protects what
+            matters most while creating space for healing and forward momentum.”
+          </blockquote>
+          <span className={styles.quoteAttribution}>— Rachel Healey</span>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/test/profile/profile.module.css
+++ b/src/app/test/profile/profile.module.css
@@ -1,0 +1,475 @@
+:root {
+  color-scheme: dark;
+}
+
+.wrapper {
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 20%, rgba(113, 91, 255, 0.35) 0%, rgba(8, 9, 17, 0.95) 55%, rgba(4, 5, 10, 1) 100%);
+  color: #f1f1f6;
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  padding-bottom: 6rem;
+}
+
+.hero {
+  position: relative;
+  padding: 7rem clamp(1.5rem, 3vw, 4rem) 4rem;
+  overflow: hidden;
+}
+
+.gradient {
+  position: absolute;
+  inset: -30% -10% auto;
+  height: 60rem;
+  background: radial-gradient(circle at 70% 30%, rgba(204, 190, 255, 0.6) 0%, rgba(50, 21, 92, 0.2) 45%, rgba(12, 13, 23, 0) 75%);
+  filter: blur(0px);
+  opacity: 0.9;
+  pointer-events: none;
+  animation: pulse 12s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+}
+
+.heroInner {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: center;
+  z-index: 1;
+}
+
+.meta {
+  grid-column: span 6;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: fade-up 0.8s ease both;
+}
+
+@keyframes fade-up {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.breadcrumb {
+  font-size: 0.875rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(241, 241, 246, 0.65);
+  margin: 0;
+}
+
+.title {
+  font-size: clamp(3.5rem, 6vw, 4.75rem);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: rgba(241, 241, 246, 0.75);
+  margin: 0;
+}
+
+.contactRow {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 2.25rem;
+  border-radius: 9999px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #b398ff 0%, #7953ff 100%);
+  color: #0b0816;
+  box-shadow: 0 20px 40px rgba(121, 83, 255, 0.35);
+}
+
+.primaryButton:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 55px rgba(121, 83, 255, 0.45);
+}
+
+.secondaryButton {
+  border: 1px solid rgba(243, 241, 255, 0.25);
+  color: rgba(241, 241, 246, 0.85);
+  background: rgba(16, 17, 31, 0.7);
+  backdrop-filter: blur(10px);
+}
+
+.secondaryButton:hover {
+  transform: translateY(-4px);
+  border-color: rgba(243, 241, 255, 0.5);
+  background: rgba(36, 37, 57, 0.85);
+}
+
+.quickFacts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1.5rem;
+  padding-top: 1rem;
+}
+
+.factLabel {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(241, 241, 246, 0.55);
+}
+
+.factValue {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.05rem;
+}
+
+.heroImageWrap {
+  position: relative;
+  grid-column: span 6;
+  display: flex;
+  justify-content: center;
+}
+
+.imageHalo {
+  position: absolute;
+  inset: auto;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(179, 152, 255, 0.6) 0%, rgba(179, 152, 255, 0) 65%);
+  filter: blur(4px);
+  z-index: 0;
+  transform: translateY(8rem);
+  opacity: 0.8;
+  animation: float 16s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(8rem) scale(1);
+  }
+  50% {
+    transform: translateY(9rem) scale(1.05);
+  }
+}
+
+.imageMask {
+  position: relative;
+  width: min(420px, 100%);
+  overflow: hidden;
+  border-radius: 50% 50% 43% 57% / 60% 55% 45% 40%;
+  mask-image: radial-gradient(circle at 50% 35%, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
+  -webkit-mask-image: radial-gradient(circle at 50% 35%, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
+  border: 2px solid rgba(243, 241, 255, 0.1);
+  box-shadow: 0 45px 80px rgba(4, 5, 14, 0.65);
+  z-index: 1;
+  animation: fade-up 0.8s ease 0.15s both;
+}
+
+.imageMask img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  filter: saturate(0.9) contrast(1.1);
+}
+
+.body {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: clamp(2rem, 6vw, 5rem);
+  padding: 0 clamp(1.5rem, 3vw, 4rem) 4rem;
+  margin-top: -2rem;
+}
+
+.intro {
+  grid-column: span 7;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  line-height: 1.7;
+  color: rgba(241, 241, 246, 0.85);
+}
+
+.intro h2 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  color: #ffffff;
+  margin: 0;
+}
+
+.intro p {
+  margin: 0;
+}
+
+.sidebar {
+  grid-column: span 5;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  position: relative;
+  padding: 2rem;
+  border-radius: 1.75rem;
+  background: linear-gradient(155deg, rgba(24, 23, 41, 0.75) 0%, rgba(16, 16, 28, 0.95) 100%);
+  border: 1px solid rgba(243, 241, 255, 0.08);
+  box-shadow: 0 24px 50px rgba(4, 6, 17, 0.55);
+  backdrop-filter: blur(14px);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 60px rgba(7, 9, 20, 0.6);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.details {
+  padding: 2rem clamp(1.5rem, 3vw, 4rem) 5rem;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: clamp(2rem, 6vw, 5rem);
+}
+
+.accordionGrid {
+  grid-column: span 7;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.accordion {
+  border-radius: 1.5rem;
+  background: rgba(16, 16, 28, 0.8);
+  border: 1px solid rgba(243, 241, 255, 0.08);
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.accordion:hover {
+  border-color: rgba(243, 241, 255, 0.2);
+  box-shadow: 0 24px 45px rgba(6, 8, 19, 0.55);
+}
+
+.accordionToggle {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.4rem 1.75rem;
+  font-size: 1.05rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.accordionToggle span {
+  pointer-events: none;
+}
+
+.icon,
+.iconOpen {
+  width: 1.5rem;
+  height: 1.5rem;
+  stroke: rgba(243, 241, 255, 0.65);
+  transition: transform 0.3s ease;
+}
+
+.iconOpen {
+  transform: rotate(45deg);
+}
+
+.accordionBody,
+.accordionBodyOpen {
+  overflow: hidden;
+  transition: grid-template-rows 0.35s ease, opacity 0.35s ease, padding 0.35s ease;
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  padding-bottom: 0;
+}
+
+.accordionBodyOpen {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  padding-bottom: 1.1rem;
+}
+
+.accordionBody ul {
+  margin: 0;
+  padding: 0 1.75rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  color: rgba(241, 241, 246, 0.75);
+  overflow: hidden;
+}
+
+.accordionBody li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.accordionBody li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #b398ff 0%, #7953ff 100%);
+  box-shadow: 0 0 12px rgba(121, 83, 255, 0.45);
+}
+
+.quoteBlock {
+  grid-column: span 5;
+  align-self: flex-start;
+  padding: 3rem;
+  border-radius: 2rem;
+  background: linear-gradient(155deg, rgba(196, 183, 255, 0.12) 0%, rgba(16, 16, 28, 0.65) 100%);
+  border: 1px solid rgba(243, 241, 255, 0.1);
+  box-shadow: 0 32px 60px rgba(7, 10, 24, 0.45);
+  backdrop-filter: blur(18px);
+  position: relative;
+}
+
+.quoteBlock::before {
+  content: '“';
+  position: absolute;
+  top: -1.5rem;
+  left: 2.5rem;
+  font-size: 6rem;
+  color: rgba(179, 152, 255, 0.15);
+  font-family: 'Playfair Display', serif;
+}
+
+.quoteBlock blockquote {
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.8;
+  color: rgba(241, 241, 246, 0.85);
+}
+
+.quoteAttribution {
+  display: block;
+  margin-top: 1.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(241, 241, 246, 0.55);
+}
+
+@media (max-width: 1024px) {
+  .heroInner,
+  .body,
+  .details {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .meta,
+  .heroImageWrap,
+  .intro,
+  .sidebar,
+  .accordionGrid,
+  .quoteBlock {
+    grid-column: span 1;
+  }
+
+  .hero {
+    padding-top: 6rem;
+  }
+
+  .imageMask {
+    width: min(360px, 80%);
+  }
+
+  .body {
+    margin-top: 0;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1 1 240px;
+  }
+
+  .quoteBlock {
+    margin-top: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .contactRow {
+    flex-direction: column;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .quoteBlock {
+    padding: 2.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a test profile page that mirrors the sample layout with a masked hero image, gradient background, and structured content sections
- implement interactive accordion sections for education, admissions, affiliations, and representative work details
- style the page to match the requested aesthetic with buttons, quote block, and responsive adjustments

## Testing
- npm run lint *(fails: prompts for ESLint configuration and must be run manually)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f751f9f0832a88b650e48b8595ef